### PR TITLE
Align license references to GNU GPLv3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A cross-platform, modular setup to manage system and dev environment configs usi
 .
 ├── .gitignore               → Global Git ignore rules
 ├── README.md                → This file
-├── LICENSE                  → MIT License
+├── LICENSE                  → GNU GPLv3
 ├── flake.nix                → Nix flake entrypoint
 │
 ├── alacritty/               → Alacritty terminal configs (.toml and .yml)
@@ -87,4 +87,4 @@ nix build .#nixosConfigurations.myhostname.config.system.build.toplevel
 
 ## 📄 License
 
-MIT — See [`LICENSE`](./LICENSE)
+GNU GPLv3 — See [`LICENSE`](./LICENSE)


### PR DESCRIPTION
## Summary
- revert license change to restore GNU GPLv3 text
- update README to reference the GNU GPLv3 license

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6843636e18fc8328bf11b4cef6b35425