### PR TITLE
Use env bash shebang in stow scripts

### DIFF
--- a/scripts/stow/cde_debian.sh
+++ b/scripts/stow/cde_debian.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Stow zsh configuration
 stow -t ~ zsh

--- a/scripts/stow/debian.sh
+++ b/scripts/stow/debian.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Stow zsh configuration
 stow -t ~ zsh

--- a/scripts/stow/terminal.sh
+++ b/scripts/stow/terminal.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Stow zsh configuration
 stow -t ~ zsh


### PR DESCRIPTION
## Summary
- ensure all shell scripts under `scripts/` use portable shebang

## Testing
- `grep -R "^#!" scripts | sort | uniq`

------
https://chatgpt.com/codex/tasks/task_e_684363a0b72083289e8d96ec418e6e1f