### PR TITLE
Add git aliases

### DIFF
--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -6,6 +6,8 @@ alias vi="nvim"
 alias vim="nvim"
 alias p2="cd ~/Nextcloud/obsidian/player2; nvim todo.md"
 alias dtf="cd ~/dotfiles; nvim"
+alias gcm="git commit -m"
+alias gco="git checkout"
 # some more ls aliases
 alias ll='ls -lh'
 alias la='ls -A'

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -18,6 +18,8 @@ alias nixc="cd ~/Repos/github.com/solrey3/nix-config/ && nvim"
 alias p2="cd ~/Repos/github.com/solrey3/notes/ && nvim todo.md"
 alias vi="nvim"
 alias vim="nvim"
+alias gcm="git commit -m"
+alias gco="git checkout"
 
 #############################################
 # Installation Instructions (if applicable)


### PR DESCRIPTION
## Summary
- add `gcm` and `gco` git aliases to Bash and Zsh configs

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684b99f47cc48328a4e08b50bc32ac4c