### PR TITLE
Add setup script for linting tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS Instructions
+
+This repository contains various dotfile configurations and setup scripts.
+
+## Code Style
+
+- Format shell scripts using `shfmt -i 2`.
+- Lint shell scripts using `shellcheck`.
+- Format Lua files using `stylua`.
+
+## Testing
+
+Before committing changes to scripts or configs, run:
+
+```bash
+shfmt -d $(git ls-files '*.sh')
+shellcheck $(git ls-files '*.sh')
+```
+
+If `nix/` or `flake.nix` is modified, attempt `nix flake check`.
+
+## PR Guidelines
+
+- Summaries should reference relevant files using repo-relative paths.
+- Include testing results in the PR body. If commands fail due to environment limits, mention it.

--- a/scripts/setup/linux/dev-tools.sh
+++ b/scripts/setup/linux/dev-tools.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Script: dev-tools.sh
+# Installs linting and formatting tools used in this repo.
+
+# 1. Install shellcheck and shfmt via apt if missing
+APT_PKGS=()
+if ! command -v shellcheck >/dev/null; then
+  APT_PKGS+=(shellcheck)
+fi
+if ! command -v shfmt >/dev/null; then
+  APT_PKGS+=(shfmt)
+fi
+if [ ${#APT_PKGS[@]} -gt 0 ]; then
+  echo "→ Installing ${APT_PKGS[*]} via apt..."
+  sudo apt-get update
+  sudo apt-get install -y "${APT_PKGS[@]}"
+else
+  echo "✅ shellcheck and shfmt already installed."
+fi
+
+# 2. Install stylua via Cargo if missing
+if command -v stylua >/dev/null; then
+  echo "✅ stylua is already installed."
+else
+  if ! command -v cargo >/dev/null; then
+    echo "→ Installing Rust and Cargo (via rustup)..."
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    # shellcheck source=/dev/null
+    source "$HOME/.cargo/env"
+  fi
+  echo "→ Installing stylua via Cargo..."
+  cargo install stylua
+fi
+
+echo "🎉 Development toolchain setup complete!"


### PR DESCRIPTION
## Summary
- add `scripts/setup/linux/dev-tools.sh` to install `shellcheck`, `shfmt` and `stylua`

## Testing
- `shfmt -d $(git ls-files '*.sh')` *(fails: command not found)*
- `shellcheck $(git ls-files '*.sh')` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685612a6133083289806513e7acc44a7