### PR TITLE
feat: modularize arch setup scripts

### DIFF
--- a/scripts/cachyos.sh
+++ b/scripts/cachyos.sh
@@ -1,64 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Fresh CachyOS COSMIC desktop setup
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# 1. Update system and install core packages
-sudo pacman -Syu \
-  zsh bash starship tmux \
-  gcc git gawk jq just openssl tokei lazygit \
-  btop htop fastfetch lsof \
-  file unzip zip p7zip \
-  rsync tree stow nnn mc \
-  curl wget nmap speedtest-cli \
-  ffmpeg yt-dlp \
-  fzf ripgrep \
-  figlet fortune-mod cowsay cmatrix \
-  kubectl k9s helm terraform \
-  nodejs yarn \
-  github-cli bitwarden-cli \
-  neovim \
-  proton-vpn-gtk-app
+SCRIPTS=(
+  "$ROOT_DIR/setup/arch/pacman-core.sh"
+  "$ROOT_DIR/setup/arch/yay.sh"
+  "$ROOT_DIR/setup/arch/aur-packages.sh"
+  "$ROOT_DIR/setup/linux/ssh-key.sh"
+  "$ROOT_DIR/setup/linux/git.sh"
+  "$ROOT_DIR/setup/linux/neovim.sh"
+  "$ROOT_DIR/setup/linux/lazyvim.sh"
+  "$ROOT_DIR/setup/linux/opencode-ai.sh"
+)
 
-# 2. Install yay AUR helper if missing
-if ! command -v yay &>/dev/null; then
-  sudo pacman -S --needed base-devel git
-  tempdir=$(mktemp -d)
-  git clone https://aur.archlinux.org/yay.git "$tempdir/yay"
-  (cd "$tempdir/yay" && makepkg -si --noconfirm)
-  rm -rf "$tempdir"
-else
-  echo "✅ yay already installed"
-fi
+echo "🔧 Running setup scripts in specified order…"
+for script in "${SCRIPTS[@]}"; do
+  if [ ! -f "$script" ]; then
+    echo "⚠️  SKIPPING missing script: $script"
+    continue
+  fi
+  echo "→ $script"
+  chmod +x "$script"
+  bash "$script"
+done
 
-# 3. Install additional packages via yay
-yay -S \
-  wezterm ghostty \
-  librewolf-bin google-chrome \
-  bitwarden 1password-cli fabric-ai
-
-# 4. Install JetBrains Mono Nerd Font
-mkdir -p ~/.local/share/fonts
-cd ~/.local/share/fonts
-wget https://github.com/ryanoasis/nerd-fonts/releases/latest/download/JetBrainsMono.zip
-unzip JetBrainsMono.zip
-fc-cache -fv
-
-# 5. Install LazyVim starter
-if [ ! -d ~/.config/nvim ]; then
-  git clone https://github.com/LazyVim/starter ~/.config/nvim
-else
-  echo "⚠️  ~/.config/nvim already exists, skipping clone"
-fi
-rm -rf ~/.config/nvim/.git
-
-# 6. Install Brave Browser
-curl -fsS https://dl.brave.com/install.sh | sh
-
-# 7. Install opencode.ai
-curl -fsSL https://opencode.ai/install | bash
-
-# 8. Set default shell to Zsh
-chsh -s "$(command -v zsh)"
-
-echo "🎉 CachyOS setup complete!"
+echo "✅ All setup steps complete!"

--- a/scripts/omarchy.sh
+++ b/scripts/omarchy.sh
@@ -1,43 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Fresh Post-Omarchy desktop setup
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# 1. Update system and install core packages
-sudo pacman -Syu \
-  base-devel zsh bash tmux starship \
-  gcc git gawk jq just openssl tokei lazygit \
-  fzf ripgrep \
-  unzip zip p7zip \
-  rsync tree stow nnn mc zoxide eza fd dysk \
-  curl wget nmap speedtest-cli \
-  ffmpeg yt-dlp \
-  figlet fortune-mod cowsay cmatrix \
-  python nodejs npm yarn \
-  networkmanager network-manager-applet proton-vpn-gtk-app nextcloud-client \
-  alacritty github-cli 
+SCRIPTS=(
+  "$ROOT_DIR/setup/arch/pacman-core.sh"
+  "$ROOT_DIR/setup/arch/yay.sh"
+  "$ROOT_DIR/setup/arch/aur-packages.sh"
+  "$ROOT_DIR/setup/linux/ssh-key.sh"
+  "$ROOT_DIR/setup/linux/git.sh"
+  "$ROOT_DIR/setup/linux/neovim.sh"
+  "$ROOT_DIR/setup/linux/lazyvim.sh"
+  "$ROOT_DIR/setup/linux/opencode-ai.sh"
+)
 
-# 2. Install yay AUR helper if missing
-if ! command -v yay &>/dev/null; then
-  sudo pacman -S --needed base-devel git
-  tempdir=$(mktemp -d)
-  git clone https://aur.archlinux.org/yay.git "$tempdir/yay"
-  (cd "$tempdir/yay" && makepkg -si --noconfirm)
-  rm -rf "$tempdir"
-else
-  echo "✅ yay already installed"
-fi
+echo "🔧 Running setup scripts in specified order…"
+for script in "${SCRIPTS[@]}"; do
+  if [ ! -f "$script" ]; then
+    echo "⚠️  SKIPPING missing script: $script"
+    continue
+  fi
+  echo "→ $script"
+  chmod +x "$script"
+  bash "$script"
+done
 
-# 3. Install additional packages via yay
-yay -S \
-  wezterm ghostty \
-  librewolf-bin google-chrome \
-  fabric-ai
-
-# 6. Install Brave Browser
-curl -fsS https://dl.brave.com/install.sh | sh
-
-# 7. Install opencode.ai
-curl -fsSL https://opencode.ai/install | bash
-
-echo "🎉 Post-Omarchy setup complete!"
+echo "✅ All setup steps complete!"

--- a/scripts/omarchy.sh
+++ b/scripts/omarchy.sh
@@ -8,9 +8,6 @@ SCRIPTS=(
   "$ROOT_DIR/setup/arch/yay.sh"
   "$ROOT_DIR/setup/arch/aur-packages.sh"
   "$ROOT_DIR/setup/linux/ssh-key.sh"
-  "$ROOT_DIR/setup/linux/git.sh"
-  "$ROOT_DIR/setup/linux/neovim.sh"
-  "$ROOT_DIR/setup/linux/lazyvim.sh"
   "$ROOT_DIR/setup/linux/opencode-ai.sh"
 )
 

--- a/scripts/setup/arch/aur-packages.sh
+++ b/scripts/setup/arch/aur-packages.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "🔄 Installing AUR packages"
+yay -S --noconfirm \
+  wezterm ghostty \
+  librewolf-bin google-chrome brave-bin \
+  bitwarden 1password-cli fabric-ai \
+  ttf-jetbrains-mono-nerd
+echo "✅ AUR packages installed"

--- a/scripts/setup/arch/pacman-core.sh
+++ b/scripts/setup/arch/pacman-core.sh
@@ -14,8 +14,6 @@ sudo pacman -Syu --noconfirm \
   python nodejs npm yarn \
   networkmanager network-manager-applet proton-vpn-gtk-app nextcloud-client \
   alacritty github-cli \
-  btop htop fastfetch lsof file \
-  kubectl k9s helm terraform \
-  neovim
+  btop htop fastfetch lsof
 
 echo "✅ Core packages installed"

--- a/scripts/setup/arch/pacman-core.sh
+++ b/scripts/setup/arch/pacman-core.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "🔄 Updating system and installing core packages"
+sudo pacman -Syu --noconfirm \
+  base-devel zsh bash tmux starship \
+  gcc git gawk jq just openssl tokei lazygit \
+  fzf ripgrep \
+  unzip zip p7zip \
+  rsync tree stow nnn mc zoxide eza fd dysk \
+  curl wget nmap speedtest-cli \
+  ffmpeg yt-dlp \
+  figlet fortune-mod cowsay cmatrix \
+  python nodejs npm yarn \
+  networkmanager network-manager-applet proton-vpn-gtk-app nextcloud-client \
+  alacritty github-cli \
+  btop htop fastfetch lsof file \
+  kubectl k9s helm terraform \
+  neovim
+
+echo "✅ Core packages installed"

--- a/scripts/setup/arch/yay.sh
+++ b/scripts/setup/arch/yay.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "🔄 Installing yay AUR helper"
+if ! command -v yay &>/dev/null; then
+  sudo pacman -S --needed --noconfirm base-devel git
+  temp_dir="$(mktemp -d)"
+  git clone https://aur.archlinux.org/yay.git "$temp_dir/yay"
+  (cd "$temp_dir/yay" && makepkg -si --noconfirm)
+  rm -rf "$temp_dir"
+else
+  echo "✅ yay already installed"
+fi

--- a/scripts/setup/linux/git.sh
+++ b/scripts/setup/linux/git.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "🔄 Configuring git"
+command -v git &>/dev/null || {
+  echo "git not installed"
+  exit 1
+}
+git config --global user.email "solrey3@solrey3.com"
+git config --global user.name "Solito Reyes III"
+echo "✅ Git configured"

--- a/scripts/setup/linux/lazyvim.sh
+++ b/scripts/setup/linux/lazyvim.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-git clone https://github.com/LazyVim/starter ~/.config/nvim
-rm -rf ~/.config/nvim/.git
+nvim_dir="$HOME/.config/nvim"
+
+if [ -d "$nvim_dir" ]; then
+  echo "✅ LazyVim already installed at $nvim_dir"
+  exit 0
+fi
+
+echo "🔄 Installing LazyVim starter template"
+git clone https://github.com/LazyVim/starter "$nvim_dir"
+echo "→ Removing git metadata"
+rm -rf "$nvim_dir/.git"
+echo "✅ LazyVim installed"

--- a/scripts/setup/linux/neovim.sh
+++ b/scripts/setup/linux/neovim.sh
@@ -5,8 +5,7 @@ echo "🔄 Ensuring Neovim is up to date"
 
 # 0. Discover latest Neovim release tag (e.g. "v0.10.5")
 echo "→ Fetching latest Neovim version…"
-NEOVIM_VERSION=$(curl -fsSL https://api.github.com/repos/neovim/neovim/releases/latest |
-  grep -Po '"tag_name": *"\K(.*)(?=")')
+NEOVIM_VERSION=$(curl -fsSL https://api.github.com/repos/neovim/neovim/releases/latest | grep -Po '"tag_name": *"\K(.*)(?=")')
 if [ -z "$NEOVIM_VERSION" ]; then
   echo "❌ Failed to determine latest Neovim version."
   exit 1

--- a/scripts/setup/linux/neovim.sh
+++ b/scripts/setup/linux/neovim.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+echo "🔄 Ensuring Neovim is up to date"
+
 # 0. Discover latest Neovim release tag (e.g. "v0.10.5")
 echo "→ Fetching latest Neovim version…"
-NEOVIM_VERSION=$(curl -fsSL https://api.github.com/repos/neovim/neovim/releases/latest \
-  | grep -Po '"tag_name": *"\K(.*)(?=")')
+NEOVIM_VERSION=$(curl -fsSL https://api.github.com/repos/neovim/neovim/releases/latest |
+  grep -Po '"tag_name": *"\K(.*)(?=")')
 if [ -z "$NEOVIM_VERSION" ]; then
   echo "❌ Failed to determine latest Neovim version."
   exit 1
@@ -52,4 +54,4 @@ rm -f "$ARCHIVE"
 echo "✅ Neovim installed. Version:"
 nvim --version | head -n1
 
-echo "🎉 Done."
+echo "🎉 Neovim setup complete"

--- a/scripts/setup/linux/opencode-ai.sh
+++ b/scripts/setup/linux/opencode-ai.sh
@@ -3,11 +3,13 @@ set -euo pipefail
 
 # Install Opencode.ai CLI
 if command -v opencode &>/dev/null; then
-  echo "✅ Opencode.ai CLI is already installed."
+  echo "✅ Opencode.ai CLI is already installed"
   exit 0
 fi
 
-echo "🔄 Installing Opencode.ai CLI…"
-curl -fsSL https://opencode.ai/install | bash
+echo "🔄 Installing Opencode.ai CLI"
+installer_url="https://opencode.ai/install"
+echo "→ Running installer from $installer_url"
+curl -fsSL "$installer_url" | bash
 
-echo "✅ Opencode.ai installation complete."
+echo "✅ Opencode.ai installation complete"

--- a/scripts/setup/linux/ssh-key.sh
+++ b/scripts/setup/linux/ssh-key.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "🔄 Generating SSH key"
+if [ ! -f "$HOME/.ssh/id_ed25519" ]; then
+  command -v ssh-keygen &>/dev/null || {
+    echo "ssh-keygen not installed"
+    exit 1
+  }
+  mkdir -p "$HOME/.ssh"
+  ssh-keygen -t ed25519 -C "solrey3@solrey3.com" -f "$HOME/.ssh/id_ed25519" -N ""
+  echo "✅ SSH key generated"
+else
+  echo "✅ SSH key already exists"
+fi

--- a/scripts/steamos.sh
+++ b/scripts/steamos.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 echo "🔄 Setting hostname to india"
 sudo hostnamectl set-hostname india
 echo "✅ Hostname set to india"
@@ -21,77 +23,26 @@ sudo pacman-key --populate
 sudo pacman -Syy --noconfirm archlinux-keyring
 echo "✅ Arch keyring reset"
 
-echo "🔄 Updating system and installing core packages"
-sudo pacman -Syu --noconfirm \
-  base-devel zsh bash tmux starship \
-  gcc git gawk jq just openssl tokei lazygit \
-  fzf ripgrep \
-  unzip zip p7zip \
-  rsync tree stow nnn mc zoxide eza fd dysk \
-  curl wget nmap speedtest-cli \
-  ffmpeg yt-dlp \
-  figlet fortune-mod cowsay cmatrix \
-  python nodejs npm yarn \
-  networkmanager network-manager-applet proton-vpn-gtk-app nextcloud-client \
-  alacritty github-cli 
+SCRIPTS=(
+  "$ROOT_DIR/setup/arch/pacman-core.sh"
+  "$ROOT_DIR/setup/arch/yay.sh"
+  "$ROOT_DIR/setup/arch/aur-packages.sh"
+  "$ROOT_DIR/setup/linux/ssh-key.sh"
+  "$ROOT_DIR/setup/linux/git.sh"
+  "$ROOT_DIR/setup/linux/neovim.sh"
+  "$ROOT_DIR/setup/linux/lazyvim.sh"
+  "$ROOT_DIR/setup/linux/opencode-ai.sh"
+)
 
-echo "✅ Core packages installed"
+echo "🔧 Running setup scripts in specified order…"
+for script in "${SCRIPTS[@]}"; do
+  if [ ! -f "$script" ]; then
+    echo "⚠️  SKIPPING missing script: $script"
+    continue
+  fi
+  echo "→ $script"
+  chmod +x "$script"
+  bash "$script"
+done
 
-required_nvim="0.11.4"
-echo "🔄 Checking Neovim version"
-if command -v nvim &>/dev/null; then
-  current_nvim="$(nvim --version | head -n1 | awk '{print $2}')"
-else
-  current_nvim="0"
-fi
-
-if [[ "$(printf '%s\n%s\n' "$required_nvim" "$current_nvim" | sort -V | tail -n1)" != "$current_nvim" ]]; then
-  echo "🔄 Installing latest Neovim"
-  tmp_dir="$(mktemp -d)"
-  curl -L https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.tar.gz -o "$tmp_dir/nvim.tar.gz"
-  tar -xzf "$tmp_dir/nvim.tar.gz" -C "$tmp_dir"
-  sudo mv "$tmp_dir/nvim-linux-x86_64" /usr/local/
-  sudo ln -sf /usr/local/nvim-linux-x86_64/bin/nvim /usr/local/bin/nvim
-  rm -rf "$tmp_dir"
-  echo "✅ Neovim installed"
-else
-  echo "✅ Neovim $current_nvim is up to date"
-fi
-
-echo "🔄 Installing yay AUR helper"
-if ! command -v yay &>/dev/null; then
-  sudo pacman -S --needed --noconfirm base-devel git
-  temp_dir="$(mktemp -d)"
-  git clone https://aur.archlinux.org/yay.git "$temp_dir/yay"
-  (cd "$temp_dir/yay" && makepkg -si --noconfirm)
-  rm -rf "$temp_dir"
-else
-  echo "✅ yay already installed"
-fi
-
-echo "🔄 Installing AUR packages"
-yay -S --noconfirm \
-  wezterm ghostty \
-  librewolf-bin google-chrome brave-bin \
-  fabric-ai \
-  ttf-jetbrains-mono-nerd
-echo "✅ AUR packages installed"
-
-echo "🔄 Generating SSH key"
-if [ ! -f "$HOME/.ssh/id_ed25519" ]; then
-  mkdir -p "$HOME/.ssh"
-  ssh-keygen -t ed25519 -C "solrey3@solrey3.com" -f "$HOME/.ssh/id_ed25519" -N ""
-  echo "✅ SSH key generated"
-else
-  echo "✅ SSH key already exists"
-fi
-
-echo "🔄 Configuring git"
-git config --global user.email "solrey3@solrey3.com"
-git config --global user.name "Solito Reyes III"
-echo "✅ Git configured"
-
-echo "🔄 Installing opencode.ai"
-curl -fsSL https://opencode.ai/install | bash
-
-echo "🎉 Post-SteamOS setup complete!"
+echo "✅ All setup steps complete!"


### PR DESCRIPTION
## Summary
- modular arch scripts for CachyOS, SteamOS and Omarchy now live in the root scripts directory
- add pacman, yay, AUR and git setup modules
- add Neovim, LazyVim and Opencode.ai setup modules
- remove automatic dotfile stow from arch scripts
- restore hostname, user and keyring initialization in SteamOS setup
- extract SSH key generation into its own module and call it before git configuration

## Testing
- `shfmt -i 2 -w scripts/setup/linux/git.sh scripts/setup/linux/ssh-key.sh scripts/cachyos.sh scripts/omarchy.sh scripts/steamos.sh`
- `shellcheck scripts/setup/linux/git.sh scripts/setup/linux/ssh-key.sh scripts/cachyos.sh scripts/omarchy.sh scripts/steamos.sh`
- `just lint-sh` *(fails: SC3011 and other errors in waybar scripts)*
- `just format-sh --diff` *(fails: Justfile does not contain recipe `--diff`)*

------
https://chatgpt.com/codex/tasks/task_e_68be3489351083289df545eb6746b021