### PR TITLE
Clean up waybar configuration

### DIFF
--- a/waybar/config
+++ b/waybar/config
@@ -9,8 +9,7 @@
     "height": 41,
     "modules-left": [
         "custom/os_button",
-        "hyprland/workspaces",
-        "wlr/taskbar"
+        "hyprland/workspaces"
     ],
     "modules-center": [],
     "modules-right": [
@@ -63,15 +62,6 @@
         "max-length": 10,
         "tooltip": true,
         "tooltip-format": "RAM - {used:0.1f}GiB used"
-    },
-    "wlr/taskbar": {
-        "format": "{icon} {title:.17}",
-        "icon-size": 28,
-        "spacing": 3,
-        "on-click-middle": "close",
-        "tooltip-format": "{title}",
-        "ignore-list": [],
-        "on-click": "activate"
     },
     "tray": {
         "icon-size": 18,

--- a/waybar/scripts/weather.sh
+++ b/waybar/scripts/weather.sh
@@ -30,8 +30,8 @@ get_weather() {
     if ! tooltip=$(timeout "$TIMEOUT" curl -fsSL "https://wttr.in/?0QT" 2>/dev/null); then
         tooltip="Weather details unavailable"
     else
-        # Properly escape the tooltip for JSON
-        tooltip=$(echo "$tooltip" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n' ' ' | sed 's/[[:space:]]*$//')
+        # Properly escape the tooltip for JSON while preserving line breaks
+        tooltip=$(echo "$tooltip" | sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/g' | tr -d '\n' | sed 's/\\n$//')
     fi
 
     # Validate we got actual weather data


### PR DESCRIPTION
## Summary
- Remove Windows-style taskbar from waybar to clean up the interface  
- Fix weather tooltip formatting to display properly formatted weather details

## Test plan
- [ ] Restart waybar and verify taskbar no longer shows active applications
- [ ] Hover over weather applet and verify tooltip shows properly formatted weather information with line breaks

🤖 Generated with [Claude Code](https://claude.ai/code)